### PR TITLE
add var to pass in vpn_client_sgs

### DIFF
--- a/_variables.tf
+++ b/_variables.tf
@@ -39,3 +39,9 @@ variable "dns_servers" {
   default     = ["", ""]
   description = "list of dns servers to use"
 }
+
+variable "vpn_client_sgs" {
+  type        = list(string)
+  default     = [""]
+  description = "security group to associate with client vpn - allows or denys traffic"
+}

--- a/vpn-endpoint.tf
+++ b/vpn-endpoint.tf
@@ -24,6 +24,7 @@ resource "aws_ec2_client_vpn_network_association" "default" {
   #count                  = length(var.subnet_ids)
   client_vpn_endpoint_id = aws_ec2_client_vpn_endpoint.default.id
   subnet_id              = element(var.subnet_ids, 0)
+  security_groups        = var.vpn_client_sgs
 }
 
 resource "aws_ec2_client_vpn_authorization_rule" "default" {


### PR DESCRIPTION
Adds the ability to pass in a list of SG's to associate with the vpn_client endpoint - e.g. allows or denies vpn traffic 